### PR TITLE
Basic github actions setup for automated releases

### DIFF
--- a/.github/workflows/UploadReleases.yml
+++ b/.github/workflows/UploadReleases.yml
@@ -23,12 +23,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - target: aarch64-apple-darwin
-            os: macos-latest
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-          - target: x86_64-apple-darwin
-            os: macos-latest
           - target: universal-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc

--- a/.github/workflows/UploadReleases.yml
+++ b/.github/workflows/UploadReleases.yml
@@ -1,0 +1,49 @@
+name: Release
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.*
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/create-gh-release-action@v1
+        with:
+          # (required) GitHub token for creating GitHub Releases.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  upload-assets:
+    needs: create-release
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: universal-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          # (required) Comma-separated list of binary names (non-extension portion of filename) to build and upload.
+          # Note that glob pattern is not supported yet.
+          bin: fbx_sanitizer
+          tar: unix
+          zip: windows
+          target: ${{ matrix.target }}
+          # (required) GitHub token for uploading assets to GitHub Releases.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          manifest-path: fbx-sanitizer/Cargo.toml


### PR DESCRIPTION
Configuring a Github Action to create cross platform binaries of fbx-sanitizer and upload them under Github Releases. It uses [this action](https://github.com/taiki-e/upload-rust-binary-action). 

**Builds created are for:**
- 64-bit MSVC (Windows 7+)
- 64-bit macOS (10.7+, Lion+)
- Arm64 macOS (11.0+, Big Sur+)
- 64 bit Linux (Kernel 3.2+, glibc 2.17+)

For a release to be created, push a tag with formatting `v[x].[y].[z]` where `[x]`, `[y]`, `[z]` are one or more digits.